### PR TITLE
Attributes

### DIFF
--- a/pages/docs/attributes.md
+++ b/pages/docs/attributes.md
@@ -5,7 +5,7 @@ description: Attributes are used to pass data to tags in Markdoc.
 
 # {% $markdoc.frontmatter.title %}
 
-Attributes let you pass data to tags
+Attributes let you pass data to Markdoc tags.
 
 ## Defining attributes
 
@@ -57,7 +57,7 @@ The following example defines an attribute for a `Callout` tag. By default, the 
 * A regular expression, array of strings, or function that takes an option and returns strings.  
 ---
 * `errorLevel`
-* Specifies how Markdoc will report a validation error.
+* Specifies how Markdoc will report a validation error. Errors are ordered according to severity. 
 * * `debug` 
   * `info`
   * `warning`


### PR DESCRIPTION
* Converted ref for attributes into a table
* Added some context under the H1. Not sure if we have defined rules about empty space between H1 and H2, but something we should chat about at some point. 
* Added some intro text before the example attribute definition to give the reader some context before they read the code. I'm cool scrapping this if we don't like it, but I think it could be helpful to intro our examples for folks scanning the page(s).