### PR TITLE
Update broken link to simple-nextjs boilerplate

### DIFF
--- a/examples/simple-nextjs/README.md
+++ b/examples/simple-nextjs/README.md
@@ -30,8 +30,8 @@ The quickest way to deploy your own version of this boilerplate is by deploying 
 
 ### Deploy with Vercel
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/docs/examples/simple-nextjs)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/docs/tree/main/examples/simple-nextjs)
 
 ### Deploy to Netlify
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/markdoc/docs/examples/simple-nextjs)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/markdoc/docs/tree/main/examples/simple-nextjs)

--- a/examples/simple-nextjs/pages/index.md
+++ b/examples/simple-nextjs/pages/index.md
@@ -9,9 +9,9 @@ This website is a lightweight boilerplate to spin up a documentation website wit
 
 ## Quick start
 
-If you want to get started right away with this boilerplate, either clone the [GitHub repository](https://github.com/markdoc/docs/examples/simple-nextjs) or deploy a version of this site to Vercel by clicking the button below.
+If you want to get started right away with this boilerplate, either clone the [GitHub repository](https://github.com/markdoc/docs/tree/main/examples/simple-nextjs) or deploy a version of this site to Vercel by clicking the button below.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/docs/examples/simple-nextjs)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/markdoc/docs/tree/main/examples/simple-nextjs)
 
 ## Get started from scratch
 


### PR DESCRIPTION
This PR is updating the link to the `simple-nextjs` subfolder in the README and main page of the boilerplate so it works with the `Deploy to Vercel` and `Deploy to Netlify` buttons.

I made a mistake in the original PR, I thought the link would be `https://github.com/markdoc/docs/examples/simple-nextjs` but it's actually `https://github.com/markdoc/docs/tree/main/examples/simple-nextjs`