### PR TITLE
Update markdoc to 0.1.1

### DIFF
--- a/examples/html-nodejs/package.json
+++ b/examples/html-nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "markdoc-html-nodejs-example",
   "private": true,
   "dependencies": {
-    "@markdoc/markdoc": "0.0.18",
+    "@markdoc/markdoc": "0.1.1",
     "express": "^4.18.1",
     "glob": "^8.0.1",
     "js-yaml": "^4.1.0",

--- a/examples/react-nodejs/package.json
+++ b/examples/react-nodejs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@markdoc/markdoc": "0.0.18",
+    "@markdoc/markdoc": "0.1.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
I noticed when using the template sites that the version couldn't be found - I assume `0.0.18` was an internal version or something. NPM only has `0.1.0` and `0.1.1`, so I figured I'd update the examples with the version from public npm: https://www.npmjs.com/package/@markdoc/markdoc