### PR TITLE
Empower people with legs to try the sandbox

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -174,11 +174,14 @@ export default function MyApp(props) {
       <TopNav>
         <Link href="/docs/getting-started">Docs</Link>
         <Link href="https://github.com/markdoc/markdoc">GitHub</Link>
-        <Link href="https://github.com/markdoc/markdoc/discussions">
+        <Link href="https://github.com/markdoc/markdoc/discussions" className="no-desktop">
+          🗨️
+        </Link>
+        <Link href="https://github.com/markdoc/markdoc/discussions" className="no-mobile">
           Community
         </Link>
         <Link href="https://twitter.com/StripeDev">Twitter</Link>
-        <span className="primary no-mobile">
+        <span className="primary">
           <Link href="/sandbox">Try</Link>
         </span>
       </TopNav>

--- a/public/globals.css
+++ b/public/globals.css
@@ -561,6 +561,12 @@ main .CodeMirror-scroll::-webkit-scrollbar {
   }
 }
 
+@media screen and (min-width: 601px) {
+  .no-desktop {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion) {
   .prefers-animation {
     display: none;


### PR DESCRIPTION
Reveal the sandbox to users of modern portable computers.

Precursor to using css grids to move SlideNav to the mobile SlideNav when on mobile.

ー Committed from a Google Pixel 6 Pro using StackBlitz, vscode.dev, Termux and Firefox for Android