### PR TITLE
html-nodejs: fix typo in 'heading.markdoc.js'

### DIFF
--- a/examples/html-nodejs/schema/heading.markdoc.js
+++ b/examples/html-nodejs/schema/heading.markdoc.js
@@ -1,4 +1,4 @@
-const { nodes } = require('.@markdoc/markdoc')
+const { nodes } = require('@markdoc/markdoc')
 
 function generateID(children, attributes) {
   if (attributes.id && typeof attributes.id === 'string') {


### PR DESCRIPTION
Fixed a typo in the 'heading.markdoc.js' file for the HTML renderer example