### PR TITLE
Normalize/simplify sentence structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Contributions and feedback are welcomed and encouraged. Feel free to open PRs he
 
 1. [Fork](https://help.github.com/articles/fork-a-repo) and [clone](https://help.github.com/articles/cloning-a-repository) this repository to your local environment.
 
-2. Create a new branch `git checkout -b <BRANCH_NAME>`
+2. Create a new branch: `git checkout -b <BRANCH_NAME>`
 
-3. Install the dependencies by running `npm install`
+3. Install the dependencies: `npm install`
 
-4. Start the development server on [http://localhost:3000](http://localhost:3000) by running `npm run dev`
+4. Start the development server on [http://localhost:3000](http://localhost:3000): `npm run dev`
 
 5. Try editing `pages/index.md`
 
 ## Code of conduct
 
-This project has adopted the Stripe [Code of conduct](https://github.com/markdoc/markdoc/blob/main/.github/CODE_OF_CONDUCT.md).
+This project has adopted the Stripe [Code of Conduct](https://github.com/markdoc/markdoc/blob/main/.github/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Contributions and feedback are welcomed and encouraged. Feel free to open PRs he
 
 1. [Fork](https://help.github.com/articles/fork-a-repo) and [clone](https://help.github.com/articles/cloning-a-repository) this repository to your local environment.
 
-2. Create a new branch: `git checkout -b <BRANCH_NAME>`
+2. Create a new branch with `git checkout -b <BRANCH_NAME>`
 
-3. Install the dependencies: `npm install`
+3. Install the dependencies by running `npm install`
 
-4. Start the development server on [http://localhost:3000](http://localhost:3000): `npm run dev`
+4. Start the development server on [http://localhost:3000](http://localhost:3000) by running `npm run dev`
 
 5. Try editing `pages/index.md`
 
 ## Code of conduct
 
-This project has adopted the Stripe [Code of Conduct](https://github.com/markdoc/markdoc/blob/main/.github/CODE_OF_CONDUCT.md).
+This project has adopted the Stripe [Code of conduct](https://github.com/markdoc/markdoc/blob/main/.github/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
Also adjust capitalization of Code of Conduct link, to match the one used in the linked document.