### PR TITLE
Improve discrimination of mobile users

### DIFF
--- a/public/globals.css
+++ b/public/globals.css
@@ -532,7 +532,7 @@ main .CodeMirror-scroll::-webkit-scrollbar {
   }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (pointer: coarse) {
   :root {
     --landing-page-max-width: 90vw;
     --font-size-jumbo: 38px;


### PR DESCRIPTION
Currently the break when shrunk to a width below 600px, which happens in splitscreen laptops. This also intentionally breaks the Try it button for tablet users, who will have a poor experience due to the broken IME support. This will not affect touch screen laptop users, but may affect convertible users intentionally.

Note that [marked ](https://marked.js.org/) makes no such distinctions. Also note that a sidebar width of 160px would work reasonably well for small screen users, it also has a nice side effect of increasing the vertical height of most navigation touch targets.