### PR TITLE
Change document.walk() to ast.walk()

### DIFF
--- a/pages/docs/render.md
+++ b/pages/docs/render.md
@@ -57,7 +57,7 @@ AST node instances also include helpful functions, like `walk`, which can be use
 ```js
 const ast = Markdoc.parse(document);
 
-for (const node of document.walk()) {
+for (const node of ast.walk()) {
   // do something with each node
 }
 ```


### PR DESCRIPTION
Thanks for this library!!

I believe it should be `ast` here.