### PR TITLE
[next-js doc] Add note about tsx for pageExtensions

### DIFF
--- a/examples/simple-nextjs/next.config.js
+++ b/examples/simple-nextjs/next.config.js
@@ -1,5 +1,5 @@
 const withMarkdoc = require('@markdoc/next.js');
 
 module.exports = withMarkdoc()({
-  pageExtensions: ['js', 'md']
+  pageExtensions: ['js', 'md', 'mdoc']
 });

--- a/pages/docs/nextjs.md
+++ b/pages/docs/nextjs.md
@@ -28,8 +28,7 @@ Follow these steps to get started with `@markdoc/next.js`.
    const withMarkdoc = require('@markdoc/next.js');
 
    module.exports = withMarkdoc(/* [options](#options) */)({
-     // You may need to include other extensions here (e.g. `tsx` if you're using Typescript)
-     pageExtensions: ['js', 'md']
+     pageExtensions: ['md', 'mdoc', 'js', 'jsx', 'ts', 'tsx']
    });
    ```
 
@@ -85,7 +84,7 @@ For example, this is how you set the `mode` to `static` to pre-render the page a
 
 ```js
 module.exports = withMarkdoc({ mode: 'static' })({
-  pageExtensions: ['js', 'md', 'mdoc']
+  pageExtensions: // [...](https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions)
 });
 ```
 
@@ -118,7 +117,7 @@ You can choose the import location for your schema by passing the `schemaPath` o
 
 ```js
 module.exports = withMarkdoc({ schemaPath: './path/to/your/markdoc/schema' })({
-  pageExtensions: ['js', 'md']
+  pageExtensions: // [...](https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions)
 });
 ```
 

--- a/pages/docs/nextjs.md
+++ b/pages/docs/nextjs.md
@@ -28,6 +28,7 @@ Follow these steps to get started with `@markdoc/next.js`.
    const withMarkdoc = require('@markdoc/next.js');
 
    module.exports = withMarkdoc(/* [options](#options) */)({
+     // You may need to include other extensions here (e.g. `tsx` if you're using Typescript)
      pageExtensions: ['js', 'md']
    });
    ```


### PR DESCRIPTION
If setting up Next.js with Typescript, this line needs `tsx` or else Typescript files won't load.

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/8083680/172079210-a66fbf4d-14a9-4716-9894-70b1a3a92bc4.png">
