### PR TITLE
Correct nextjs getServerSideProps link

### DIFF
--- a/pages/docs/nextjs.md
+++ b/pages/docs/nextjs.md
@@ -76,7 +76,7 @@ You can pass options to `withMarkdoc` to adjust how the plugin behaves.
 
 - `mode`
 - `'static' | 'server'`
-- Determines whether the generated Markdoc pages use [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props) or [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props).
+- Determines whether the generated Markdoc pages use [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props) or [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props).
 
 {% /table %}
 


### PR DESCRIPTION
In the `withMarkdoc` options table there are two links to the Next.js docs under the `mode` description.

The `getServerSideProps` link goes to the `getStaticProps` page however. This PR fixes that link.