### PR TITLE
Use ValidationError[] return type for validate method

### DIFF
--- a/pages/docs/validation.md
+++ b/pages/docs/validation.md
@@ -10,7 +10,7 @@ description: Extend Markdoc to provide custom validation for your documents.
 Markdoc supports syntax validation out of the box using the `validate` function.
 
 ```ts
-validate(AstNode, ?Config) => ValidateError[]
+validate(AstNode, ?Config) => ValidationError[]
 ```
 
 \


### PR DESCRIPTION
The docs (https://markdoc.io/docs/validation) say the return value for `validate()` is `ValidateError[]`, but it looks like it should be `ValidationError[]` :
```
validate(AstNode, ?Config) => ValidateError[]
```

Here are the two types:
```
export type ValidationError = {
  id: string;
  level: 'debug' | 'info' | 'warning' | 'error' | 'critical';
  message: string;
  location?: Location;
};

export type ValidateError = {
  type: string;
  lines: number[];
  location?: Location;
  error: ValidationError;
};
```