### PR TITLE
Annotations and attributes

### DIFF
--- a/pages/docs/attributes.md
+++ b/pages/docs/attributes.md
@@ -5,7 +5,73 @@ description: Attributes are used to pass data to tags in Markdoc.
 
 # {% $markdoc.frontmatter.title %}
 
+
 Attributes let you pass data to Markdoc tags, similar to [HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes) or [React props](https://reactjs.org/docs/components-and-props.html).
+
+You can pass values of type: `number`, `string`, `boolean`, JSON `array`, or JSON `object`, either directly or using [variables](/docs/variables). With a tag, you can use HTML-like syntax.
+
+{% markdoc-example %}
+
+```
+{% city
+   index=0
+   name="San Francisco"
+   deleted=false
+   coordinates=[1, 4, 9]
+   meta={id: "id_123"}
+   color=$color /%}
+```
+
+{% /markdoc-example %}
+
+To pass attributes to a node, you can't use the HTML-like syntax. Instead, use _annotation_ syntax. Put the attributes after the node, in their own set of `{%` and `%}`.
+
+{% markdoc-example %}
+
+```
+{% table %}
+
+- Function {% width="25%" %}
+- Returns  {% colspan=2 %}
+- Example  {% align=$side %}
+
+{% /table %}
+```
+
+{% /markdoc-example %}
+
+(Annotation syntax also works with tags. But it's required with nodes.)
+
+Strings within attributes must be double-quoted. If you want to include a literal double-quote in a string you can escape it with using \\".
+
+{% markdoc-example %}
+
+``` {% process=false %}
+{% data delimiter="\"" /%}
+```
+
+{% /markdoc-example %}
+
+
+## Attribute shorthand 
+
+
+In either syntax, you can use `.my-class-name` and `#my-id` as shorthand for `class=my-class-name` and `id=my-id`.
+
+{% markdoc-example %}
+
+``` {% process=false %}
+# Examples {% #examples %}
+
+{% table .striped #exampletable %}
+- One 
+- Two
+- Three
+{% /table %}
+```
+
+{% /markdoc-example %}
+
 
 ## Defining attributes
 

--- a/pages/docs/functions.md
+++ b/pages/docs/functions.md
@@ -7,55 +7,6 @@ description: Functions let you extend Markdoc to run custom code.
 
 Functions enable you extend Markdoc with custom utilities, which let you transform your content and [variables](/docs/syntax#variables) at runtime.
 
-## Creating a custom function
-
-To extend Markdoc with your own functions, first create custom function definitions:
-
-```js
-const includes = {
-  transform(parameters) {
-    const [array, value] = Object.values(parameters);
-
-    return Array.isArray(array) ? array.includes(value) : false;
-  }
-};
-
-const uppercase = {
-  transform(parameters) {
-    const string = parameters[0];
-
-    return typeof string === 'string' ? string.toUpperCase() : string;
-  }
-};
-```
-
-Then, pass the functions to your [`Config` object](/docs/syntax#config)
-
-```js
-const config = {
-  functions: {
-    includes,
-    uppercase
-  }
-};
-
-const content = Markdoc.transform(ast, config);
-```
-
-Finally, call the functions within your Markdoc content
-
-{% markdoc-example %}
-
-```md
-{% if includes($countries, "AR") %} 🇦🇷 {% /if %}
-{% if includes($countries, "AU") %} 🇦🇺 {% /if %}
-{% if includes($countries, "ES") %} 🇪🇸 {% /if %}
-{% if includes($countries, "JP") %} 🇯🇵 {% /if %}
-{% if includes($countries, "NG") %} 🇳🇬 {% /if %}
-{% if includes($countries, "US") %} 🇺🇸 {% /if %}
-```
-
-{% /markdoc-example %}
 
 ## Built-in functions
 
@@ -167,6 +118,57 @@ This function simply renders the value as a serialized JSON value in the documen
 
 ```
 {% debug($myVar) %}
+```
+
+{% /markdoc-example %}
+
+
+## Creating a custom function
+
+To extend Markdoc with your own functions, first create custom function definitions:
+
+```js
+const includes = {
+  transform(parameters) {
+    const [array, value] = Object.values(parameters);
+
+    return Array.isArray(array) ? array.includes(value) : false;
+  }
+};
+
+const uppercase = {
+  transform(parameters) {
+    const string = parameters[0];
+
+    return typeof string === 'string' ? string.toUpperCase() : string;
+  }
+};
+```
+
+Then, pass the functions to your [`Config` object](/docs/syntax#config)
+
+```js
+const config = {
+  functions: {
+    includes,
+    uppercase
+  }
+};
+
+const content = Markdoc.transform(ast, config);
+```
+
+Finally, call the functions within your Markdoc content
+
+{% markdoc-example %}
+
+```md
+{% if includes($countries, "AR") %} 🇦🇷 {% /if %}
+{% if includes($countries, "AU") %} 🇦🇺 {% /if %}
+{% if includes($countries, "ES") %} 🇪🇸 {% /if %}
+{% if includes($countries, "JP") %} 🇯🇵 {% /if %}
+{% if includes($countries, "NG") %} 🇳🇬 {% /if %}
+{% if includes($countries, "US") %} 🇺🇸 {% /if %}
 ```
 
 {% /markdoc-example %}

--- a/pages/docs/nodes.md
+++ b/pages/docs/nodes.md
@@ -5,135 +5,9 @@ description:
 
 # {% $markdoc.frontmatter.title %}
 
-Markdoc nodes enable you to customize how your document renders without using any custom syntax—it consists entirely of Markdown. Customizing nodes lets you extend your implementation incrementally.
 
-## Customizing Markdoc nodes
+Nodes are elements that Markdoc inherits from Markdown, specifically the [CommonMark specification](https://commonmark.org/). Markdoc nodes enable you to customize how your document renders without using any custom syntax—it consists entirely of Markdown. Customizing nodes lets you extend your implementation incrementally.
 
-Nodes are elements that Markdoc inherits from Markdown, specifically the [CommonMark specification](https://commonmark.org/).
-
-You define custom nodes by passing a custom Node to your [`Config`](/docs/syntax#config), like:
-
-```js
-import { heading } from './schema/Heading.markdoc';
-import * as components from './components';
-
-const config = {
-  nodes: {
-    heading
-  }
-};
-
-const ast = Markdoc.parse(doc);
-const content = Markdoc.transform(ast, config);
-
-const children = Markdoc.renderers.react(content, React, { components });
-```
-
-where `heading` looks something like:
-
-```js
-// ./schema/Heading.markdoc.js
-
-import { Tag } from '@markdoc/markdoc';
-
-// Or replace this with your own function
-function generateID(children, attributes) {
-  if (attributes.id && typeof attributes.id === 'string') {
-    return attributes.id;
-  }
-  return children
-    .filter((child) => typeof child === 'string')
-    .join(' ')
-    .replace(/[?]/g, '')
-    .replace(/\s+/g, '-')
-    .toLowerCase();
-}
-
-export const heading = {
-  children: ['inline'],
-  attributes: {
-    id: { type: String },
-    level: { type: Number, required: true, default: 1 }
-  },
-  transform(node, config) {
-    const attributes = node.transformAttributes(config);
-    const children = node.transformChildren(config);
-
-    const id = generateID(children, attributes);
-
-    return new Tag(
-      `h${node.attributes['level']}`,
-      { ...attributes, id },
-      children
-    );
-  }
-};
-```
-
-After registering this custom node, you can then use it in your Markdoc, like:
-
-{% side-by-side %}
-
-{% markdoc-example %}
-
-```md
-#### My header
-```
-
-{% /markdoc-example %}
-
-#### My header
-
-{% /side-by-side %}
-
-## Options
-
-These are the optional fields you can use to customize your `Node`:
-
-{% table %}
-
-- Option
-- Type
-- Description {% width="40%" %}
-
----
-
-- `render`
-- `string`
-- Name of the output (for example, HTML tag, React component name) to render
-
----
-
-- `children`
-- `string[]`
-- Determines which tag or node types can be rendered as children of this node. Used in schema validation.
-
----
-
-- `attributes`
-- `{ [string]: SchemaAttribute }`
-- Determines which [values (and their types)](/docs/attributes) can be passed to this node.
-
----
-
-- `transform`
-- ```js
-  (Ast.Node, ?Options) =>
-    | RenderableTreeNode
-    | RenderableTreeNode[]
-    | null
-  ```
-- Customize the Markdoc transform function for this node, returning the custom output you want to eventually render. This is called during the [`transform` step](/docs/render#transform).
-
----
-
-- `validate`
-- ```js
-  (Node, ?Options) => ValidationError[];
-  ```
-- Extend Markdoc validation. This validates that the content meets validation requirements, and is called during the [`validate` step](/docs/render#validate)
-
-{% /table %}
 
 ## Built-in nodes
 
@@ -289,6 +163,133 @@ Markdoc comes out of the box with built-in nodes for each of the [CommonMark](ht
 
 - `error`
 - —
+
+{% /table %}
+
+
+## Customizing Markdoc nodes
+
+You define custom nodes by passing a custom Node to your [`Config`](/docs/syntax#config), like:
+
+```js
+import { heading } from './schema/Heading.markdoc';
+import * as components from './components';
+
+const config = {
+  nodes: {
+    heading
+  }
+};
+
+const ast = Markdoc.parse(doc);
+const content = Markdoc.transform(ast, config);
+
+const children = Markdoc.renderers.react(content, React, { components });
+```
+
+where `heading` looks something like:
+
+```js
+// ./schema/Heading.markdoc.js
+
+import { Tag } from '@markdoc/markdoc';
+
+// Or replace this with your own function
+function generateID(children, attributes) {
+  if (attributes.id && typeof attributes.id === 'string') {
+    return attributes.id;
+  }
+  return children
+    .filter((child) => typeof child === 'string')
+    .join(' ')
+    .replace(/[?]/g, '')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+}
+
+export const heading = {
+  children: ['inline'],
+  attributes: {
+    id: { type: String },
+    level: { type: Number, required: true, default: 1 }
+  },
+  transform(node, config) {
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config);
+
+    const id = generateID(children, attributes);
+
+    return new Tag(
+      `h${node.attributes['level']}`,
+      { ...attributes, id },
+      children
+    );
+  }
+};
+```
+
+After registering this custom node, you can then use it in your Markdoc, like:
+
+{% side-by-side %}
+
+{% markdoc-example %}
+
+```md
+#### My header
+```
+
+{% /markdoc-example %}
+
+#### My header
+
+{% /side-by-side %}
+
+## Options
+
+These are the optional fields you can use to customize your `Node`:
+
+{% table %}
+
+- Option
+- Type
+- Description {% width="40%" %}
+
+---
+
+- `render`
+- `string`
+- Name of the output (for example, HTML tag, React component name) to render
+
+---
+
+- `children`
+- `string[]`
+- Determines which tag or node types can be rendered as children of this node. Used in schema validation.
+
+---
+
+- `attributes`
+- `{ [string]: SchemaAttribute }`
+- Determines which [values (and their types)](/docs/attributes) can be passed to this node.
+
+---
+
+- `transform`
+- ```js
+  (Ast.Node, ?Options) =>
+    | RenderableTreeNode
+    | RenderableTreeNode[]
+    | null
+  ```
+- Customize the Markdoc transform function for this node, returning the custom output you want to eventually render. This is called during the [`transform` step](/docs/render#transform).
+
+---
+
+- `validate`
+- ```js
+  (Node, ?Options) => ValidationError[];
+  ```
+- Extend Markdoc validation. This validates that the content meets validation requirements, and is called during the [`validate` step](/docs/render#validate)
 
 {% /table %}
 

--- a/pages/docs/syntax.md
+++ b/pages/docs/syntax.md
@@ -173,7 +173,7 @@ You can also set [attributes](#attributes) on a node, such as `width` or `colspa
 
 ## Attributes
 
-Pass attributes to tags to customize their behavior. You can pass values of type: `number`, `string`, `boolean`, JSON `array`, or JSON `object`.
+With tags, you can use an HTML-like syntax:
 
 {% markdoc-example %}
 
@@ -183,13 +183,26 @@ Pass attributes to tags to customize their behavior. You can pass values of type
    name="San Francisco"
    deleted=false
    coordinates=[1, 4, 9]
-   meta={id: "id_123"} /%}
+   meta={id: "id_123"} 
+   color=$color /%}
 ```
 
 {% /markdoc-example %}
 
-All Markdoc strings use double-quotes. This includes when passing a string as an attribute or as a [function](#functions) parameter.  
-If you want to include a double-quote in a string you can escape it with using `\"`.
+Because the HTML-like syntax doesn't work with nodes, we offer another option: write the attributes after the tag or node you're passing them to, in a separate set of `{%` and `%}`. 
+
+{% markdoc-example %}
+
+```
+{% table %}
+* Cell
+* Cell
+---
+* Cell {% colspan=2 %}
+{% /table %}
+```
+
+{% /markdoc-example %}
 
 \
 For more information, check out the [Attributes docs](/docs/attributes).

--- a/pages/docs/tags.md
+++ b/pages/docs/tags.md
@@ -29,154 +29,6 @@ Tags aren't composable!
 
 {% /markdoc-example %}
 
-## Create a custom tag
-
-To extend Markdoc with a custom tag, first, create a tag definition. In this example, you're creating a `callout` tag:
-
-```js
-// ./schema/Callout.markdoc.js
-
-export const callout = {
-  render: 'Callout',
-  children: ['paragraph', 'tag', 'list'],
-  attributes: {
-    type: {
-      type: String,
-      default: 'note',
-      matches: ['caution', 'check', 'note', 'warning'],
-      errorLevel: 'critical'
-    },
-    title: {
-      type: String
-    }
-  }
-};
-```
-
-Then, pass the tag definition to your [`Config` object](/docs/syntax#config):
-
-```js
-import { callout } from './schema/Callout.markdoc';
-import * as components from './components';
-
-const config = {
-  tags: {
-    callout
-  }
-};
-
-const doc = `
-# My first custom tag
-`;
-
-const ast = Markdoc.parse(doc);
-const content = Markdoc.transform(ast, config);
-
-const children = Markdoc.renderers.react(content, React, { components });
-```
-
-Next, pass your content to the Markdoc renderer. If you want to render a React component, specify which component should render this type of tag in the `components` mapping.
-
-```jsx
-import * as React from 'react';
-import { Icon } from './Icon';
-
-function Callout({ title, icon, children }) {
-  return (
-    <div className="callout">
-      <div className="content">
-        <Icon icon={icon} />
-        <div className="copy">
-          <span className="title">{title}</span>
-          <span>{children}</span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-return Markdoc.renderers.react(content, React, {
-  components: {
-    // The key here is the same string as `tag` in the previous step
-    Callout: Callout
-  }
-});
-```
-
-Now you can use your custom tag in your Markdoc content.
-
-{% side-by-side %}
-
-{% markdoc-example %}
-
-```md
-{% callout title="Hey you!" icon="note" %}
-I have a message for you
-{% /callout %}
-```
-
-{% /markdoc-example %}
-
-{% callout title="Hey you!" type="note" %}
-I have a message for you
-{% /callout %}
-
-{% /side-by-side %}
-
-## Options
-
-These are the optional fields you can use to customize your `Tag`:
-
-{% table %}
-
-- Option
-- Type
-- Description {% width="40%" %}
-
----
-
-- `render`
-- `string`
-- Name of the output (for example, HTML tag, React component name) to render
-
----
-
-- `children`
-- `string[]`
-- Specifies which node types can be rendered as children of this tag. Used in schema validation.
-
----
-
-- `attributes`
-- `{ [string]: SchemaAttribute }`
-- Specifies which [values (and their types)](/docs/attributes) can be passed to this tag.
-
----
-
-- `transform`
-- ```js
-  (Ast.Node, ?Options) =>
-    | RenderableTreeNode
-    | RenderableTreeNode[]
-    | null
-  ```
-- Customize the Markdoc transform function for this tag, returning the custom output you want to eventually render. This is called during the [`transform` step](/docs/render#transform).
-
----
-
-- `validate`
-- ```js
-  (Node, ?Options) => ValidationError[];
-  ```
-- Extend Markdoc validation. Used to validate that the content meets validation requirements. This is called during the [`validate` step](/docs/render#validate)
-
----
-
-- `selfClosing`
-- `boolean`
-- Specifies whether a tag can contain children (`false`) or not (`true`). Used in schema validation.
-
-{% /table %}
 
 ## Built-in tags
 
@@ -384,6 +236,156 @@ Here is an example of including the `header.md` file as a partial.
 {% /markdoc-example %}
 
 For more information on partials, check out the full [partials docs](/docs/partials).
+
+
+## Create a custom tag
+
+To extend Markdoc with a custom tag, first, create a tag definition. In this example, you're creating a `callout` tag:
+
+```js
+// ./schema/Callout.markdoc.js
+
+export const callout = {
+  render: 'Callout',
+  children: ['paragraph', 'tag', 'list'],
+  attributes: {
+    type: {
+      type: String,
+      default: 'note',
+      matches: ['caution', 'check', 'note', 'warning'],
+      errorLevel: 'critical'
+    },
+    title: {
+      type: String
+    }
+  }
+};
+```
+
+Then, pass the tag definition to your [`Config` object](/docs/syntax#config):
+
+```js
+import { callout } from './schema/Callout.markdoc';
+import * as components from './components';
+
+const config = {
+  tags: {
+    callout
+  }
+};
+
+const doc = `
+# My first custom tag
+`;
+
+const ast = Markdoc.parse(doc);
+const content = Markdoc.transform(ast, config);
+
+const children = Markdoc.renderers.react(content, React, { components });
+```
+
+Next, pass your content to the Markdoc renderer. If you want to render a React component, specify which component should render this type of tag in the `components` mapping.
+
+```jsx
+import * as React from 'react';
+import { Icon } from './Icon';
+
+function Callout({ title, icon, children }) {
+  return (
+    <div className="callout">
+      <div className="content">
+        <Icon icon={icon} />
+        <div className="copy">
+          <span className="title">{title}</span>
+          <span>{children}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+return Markdoc.renderers.react(content, React, {
+  components: {
+    // The key here is the same string as `tag` in the previous step
+    Callout: Callout
+  }
+});
+```
+
+Now you can use your custom tag in your Markdoc content.
+
+{% side-by-side %}
+
+{% markdoc-example %}
+
+```md
+{% callout title="Hey you!" icon="note" %}
+I have a message for you
+{% /callout %}
+```
+
+{% /markdoc-example %}
+
+{% callout title="Hey you!" type="note" %}
+I have a message for you
+{% /callout %}
+
+{% /side-by-side %}
+
+## Options
+
+These are the optional fields you can use to customize your `Tag`:
+
+{% table %}
+
+- Option
+- Type
+- Description {% width="40%" %}
+
+---
+
+- `render`
+- `string`
+- Name of the output (for example, HTML tag, React component name) to render
+
+---
+
+- `children`
+- `string[]`
+- Specifies which node types can be rendered as children of this tag. Used in schema validation.
+
+---
+
+- `attributes`
+- `{ [string]: SchemaAttribute }`
+- Specifies which [values (and their types)](/docs/attributes) can be passed to this tag.
+
+---
+
+- `transform`
+- ```js
+  (Ast.Node, ?Options) =>
+    | RenderableTreeNode
+    | RenderableTreeNode[]
+    | null
+  ```
+- Customize the Markdoc transform function for this tag, returning the custom output you want to eventually render. This is called during the [`transform` step](/docs/render#transform).
+
+---
+
+- `validate`
+- ```js
+  (Node, ?Options) => ValidationError[];
+  ```
+- Extend Markdoc validation. Used to validate that the content meets validation requirements. This is called during the [`validate` step](/docs/render#validate)
+
+---
+
+- `selfClosing`
+- `boolean`
+- Specifies whether a tag can contain children (`false`) or not (`true`). Used in schema validation.
+
+{% /table %}
 
 ## Next steps
 


### PR DESCRIPTION
Right now, we've got two related problems:

1. The IA implies that `/docs/attributes` is the most detailed source on attributes — but some attribute info is only in `/docs/syntax`, making the whole story hard to find
2. The structure of `/docs/syntax` implies that annotations are a separate feature — but there's no `/docs/annotations`, making the whole story hard to find

This PR addresses those by pushing most attribute _and_ annotation info into `/docs/attributes`, and by adding language that clarifies that annotations are just an alternate syntax for passing attributes. 