### PR TITLE
Moving content into specific articles

### DIFF
--- a/components/Shell/SideNav.js
+++ b/components/Shell/SideNav.js
@@ -25,6 +25,10 @@ const items = [
         href: '/docs/render',
         children: 'Rendering'
       },
+      {
+        href: '/docs/config',
+        children: 'Config objects'
+      },
       { href: '/docs/validation', children: 'Validation' }
     ]
   },

--- a/pages/docs/attributes.md
+++ b/pages/docs/attributes.md
@@ -169,7 +169,7 @@ export class DateTime {
 }
 ```
 
-Then, pass the custom attribute to your tag definition in your [`Config` object](/docs/syntax#config)
+Then, pass the custom attribute to your tag definition in your [`config` object](/docs/config).
 
 ```js
 import { DateTime } from './attribute-types/DateTime';

--- a/pages/docs/config.md
+++ b/pages/docs/config.md
@@ -1,0 +1,109 @@
+---
+title: Config objects
+description: Pass customizations into the rendering pipeline using a config object
+---
+
+# {% $markdoc.frontmatter.title %}
+
+When you customize Markdoc, you must pass your customization into the rendering pipeline. The most common way to do this is to provide a config object to the [transform](/docs/render#transform) phase of rendering. 
+
+For instance, create a config object that specifies the variable `$version` has a value of `"1.0"`. Then, pass it to the `transform` function.
+
+{% markdoc-example %}
+```js
+const config = { variables: { version: "1.0" }};
+const ast = Markdoc.parse("This is version {% $version %}");
+const content = Markdoc.transform(ast, config);
+const html = Markdoc.renderers.html(content);
+```
+{% /markdoc-example %}
+
+## Options
+
+This table outlines the various options you can pass in a config object.
+
+{% table %}
+
+- Key
+- Type
+- Description
+
+---
+
+- [`nodes`](/docs/nodes)
+- {% code %}{ [nodeType: [NodeType](/docs/nodes#built-in-nodes)]: [Schema](https://github.com/markdoc/markdoc/blob/6bcb8a0c48a181ca9df577534d841280646cea09/src/types.ts#L94-L101) }{% /code%}
+- Register [custom nodes](/docs/nodes) in your schema
+
+---
+
+- [`tags`](/docs/tags)
+- {% code %}{ [tagName: string]: [Schema](https://github.com/markdoc/markdoc/blob/6bcb8a0c48a181ca9df577534d841280646cea09/src/types.ts#L94-L101) }{% /code%}
+- Register [custom tags](/docs/tags) in your schema
+
+---
+
+- [`variables`](/docs/variables)
+- `{ [variableName: string]: any }`
+- Register [variables](/docs/variables) to use in your document
+
+---
+
+- [`functions`](/docs/functions)
+- {% code %}{ [functionName: string]: [ConfigFunction](https://github.com/markdoc/markdoc/blob/6bcb8a0c48a181ca9df577534d841280646cea09/src/types.ts#L31-L36) }{% /code %}
+- Register [custom functions](/docs/functions) to use in your document
+
+---
+
+- [`partials`](/docs/partials)
+- `{ [partialPath: string]: Ast.Node }`
+- Register reusable pieces of content to used by the [`partial` tag](/docs/partials)
+
+{% /table %}
+
+## Full example
+
+Here's an example of what a Markdoc config would look like:
+
+```js
+const config = {
+  nodes: {
+    heading: {
+      render: 'Heading',
+      attributes: {
+        id: { type: String },
+        level: { type: Number }
+      }
+    }
+  },
+  tags: {
+    callout: {
+      render: 'Callout',
+      attributes: {
+        title: {
+          type: String
+        }
+      }
+    }
+  },
+  variables: {
+    name: 'Dr. Mark',
+    frontmatter: {
+      title: 'Configuration options'
+    }
+  },
+  functions: {
+    includes: {
+      transform(parameters, config) {
+        const [array, value] = Object.values(parameters);
+
+        return Array.isArray(array) ? array.includes(value) : false;
+      }
+    }
+  },
+  partials: {
+    'header.md': Markdoc.parse(`# My header`)
+  }
+};
+
+const content = Markdoc.transform(ast, config);
+```

--- a/pages/docs/frontmatter.md
+++ b/pages/docs/frontmatter.md
@@ -83,7 +83,7 @@ const ast = Markdoc.parse(doc);
 
 ### Parse the frontmatter
 
-Parse the frontmatter attribute using your preferred format and pass it to your `variables` config.
+Parse the frontmatter attribute using your preferred format and pass it in the `variables` field of your [`config` object](/docs/config).
 
 ```js
 import yaml from 'js-yaml'; // or 'toml', etc.

--- a/pages/docs/functions.md
+++ b/pages/docs/functions.md
@@ -145,7 +145,7 @@ const uppercase = {
 };
 ```
 
-Then, pass the functions to your [`Config` object](/docs/syntax#config)
+Then, pass the functions to your [`config` object](/docs/config).
 
 ```js
 const config = {

--- a/pages/docs/getting-started.md
+++ b/pages/docs/getting-started.md
@@ -46,7 +46,7 @@ const ast = Markdoc.parse(source);
 {% comment %}
 // prettier-ignore
 {% /comment %}
-const content = Markdoc.transform(ast, /* [config](/docs/syntax#config) */);
+const content = Markdoc.transform(ast, /* [config](/docs/config) */);
 
 const html = Markdoc.renderers.html(content);
 ```

--- a/pages/docs/nodes.md
+++ b/pages/docs/nodes.md
@@ -169,7 +169,7 @@ Markdoc comes out of the box with built-in nodes for each of the [CommonMark](ht
 
 ## Customizing Markdoc nodes
 
-You define custom nodes by passing a custom Node to your [`Config`](/docs/syntax#config), like:
+You define custom nodes by passing a custom Node to your [`config` object](/docs/config), like:
 
 ```js
 import { heading } from './schema/Heading.markdoc';

--- a/pages/docs/partials.md
+++ b/pages/docs/partials.md
@@ -18,7 +18,7 @@ Here's an example of including the `header.md` file as a partial.
 
 #### Registering partials
 
-You define partials by creating a mapping from the file name to an abstract syntax tree (AST) node in your [`Config` object](/docs/syntax#config). The default `partial` [tag](/docs/tags) looks at this config to include the right content.
+You define partials by creating a mapping from the file name to an abstract syntax tree (AST) node in your [`config` object](/docs/config). The default `partial` [tag](/docs/tags) looks at this config to include the right content.
 
 {% markdoc-example %}
 

--- a/pages/docs/syntax.md
+++ b/pages/docs/syntax.md
@@ -86,31 +86,6 @@ Content
 
 {% /markdoc-example %}
 
-Tags can be self-closing (similar to HTML). In this example, you'll see that the content body is removed, and that the tag is closed with a `/`.
-
-{% markdoc-example %}
-
-```
-{% image width=40 /%}
-```
-
-{% /markdoc-example %}
-
-If your tag doesn't contain any new lines, then it's treated as an inline tag. Inline tags are automatically wrapped with a single `paragraph` [Node](/docs/nodes) (which renders a `<p>` element by default), to follow the [CommonMark paragraph spec](https://spec.commonmark.org/0.30/#paragraphs).
-
-{% markdoc-example %}
-
-```
-{% code %}
-
-{% highlight %}Inline tag 1{% /highlight %}
-{% highlight %}Inline tag 2{% /highlight %}
-
-{% /code %}
-```
-
-{% /markdoc-example %}
-
 \
 For more information, check out the [Tags docs](/docs/tags).
 
@@ -226,96 +201,6 @@ Markdoc supports [Markdown comment syntax](https://spec.commonmark.org/0.30/#exa
 ```
 
 {% /markdoc-example %}
-
-## Config
-
-This table outlines the various options you can pass to `Markdoc.transform`. Each option adjusts how a document is [transformed](/docs/render#transform) and [rendered](/docs/render#render).
-
-{% table %}
-
-- Key
-- Type
-- Description
-
----
-
-- [`nodes`](/docs/nodes)
-- {% code %}{ [nodeType: [NodeType](/docs/nodes#built-in-nodes)]: [Schema](https://github.com/markdoc/markdoc/blob/6bcb8a0c48a181ca9df577534d841280646cea09/src/types.ts#L94-L101) }{% /code%}
-- Register [custom nodes](/docs/nodes) in your schema
-
----
-
-- [`tags`](/docs/tags)
-- {% code %}{ [tagName: string]: [Schema](https://github.com/markdoc/markdoc/blob/6bcb8a0c48a181ca9df577534d841280646cea09/src/types.ts#L94-L101) }{% /code%}
-- Register [custom tags](/docs/tags) in your schema
-
----
-
-- [`variables`](/docs/variables)
-- `{ [variableName: string]: any }`
-- Register [variables](/docs/variables) to use in your document
-
----
-
-- [`functions`](/docs/functions)
-- {% code %}{ [functionName: string]: [ConfigFunction](https://github.com/markdoc/markdoc/blob/6bcb8a0c48a181ca9df577534d841280646cea09/src/types.ts#L31-L36) }{% /code %}
-- Register [custom functions](/docs/functions) to use in your document
-
----
-
-- [`partials`](/docs/partials)
-- `{ [partialPath: string]: Ast.Node }`
-- Register reusable pieces of content to used by the [`partial` tag](/docs/partials)
-
-{% /table %}
-
-### Full example
-
-Here's an example of what a Markdoc config would look like:
-
-```js
-const config = {
-  nodes: {
-    heading: {
-      render: 'Heading',
-      attributes: {
-        id: { type: String },
-        level: { type: Number }
-      }
-    }
-  },
-  tags: {
-    callout: {
-      render: 'Callout',
-      attributes: {
-        title: {
-          type: String
-        }
-      }
-    }
-  },
-  variables: {
-    name: 'Dr. Mark',
-    frontmatter: {
-      title: 'Configuration options'
-    }
-  },
-  functions: {
-    includes: {
-      transform(parameters, config) {
-        const [array, value] = Object.values(parameters);
-
-        return Array.isArray(array) ? array.includes(value) : false;
-      }
-    }
-  },
-  partials: {
-    'header.md': Markdoc.parse(`# My header`)
-  }
-};
-
-const content = Markdoc.transform(ast, config);
-```
 
 ## Next steps
 

--- a/pages/docs/tags.md
+++ b/pages/docs/tags.md
@@ -27,6 +27,32 @@ Tags aren't composable!
 {% /if %}
 ```
 
+Tags can be self-closing (similar to HTML). In this example, you'll see that the content body is removed, and that the tag is closed with a `/`.
+
+{% markdoc-example %}
+
+```
+{% image width=40 /%}
+```
+
+{% /markdoc-example %}
+
+If your tag doesn't contain any new lines, then it's treated as an inline tag. Inline tags are automatically wrapped with a single `paragraph` [Node](/docs/nodes) (which renders a `<p>` element by default), to follow the [CommonMark paragraph spec](https://spec.commonmark.org/0.30/#paragraphs).
+
+{% markdoc-example %}
+
+```
+{% code %}
+
+{% highlight %}Inline tag 1{% /highlight %}
+{% highlight %}Inline tag 2{% /highlight %}
+
+{% /code %}
+```
+
+{% /markdoc-example %}
+
+
 {% /markdoc-example %}
 
 

--- a/pages/docs/tags.md
+++ b/pages/docs/tags.md
@@ -288,7 +288,7 @@ export const callout = {
 };
 ```
 
-Then, pass the tag definition to your [`Config` object](/docs/syntax#config):
+Then, pass the tag definition to your [`config` object](/docs/config):
 
 ```js
 import { callout } from './schema/Callout.markdoc';

--- a/pages/docs/variables.md
+++ b/pages/docs/variables.md
@@ -17,7 +17,7 @@ Here I am rendering a custom {% $variable %}
 
 You can pass variables in a few ways:
 
-1. Through the `variables` field on your [`Config`](/docs/syntax#config)
+1. Through the `variables` field on your [`config` object](/docs/config)
 2. Via the [`variables` attribute](#with-partials) on a [`partial` tag](/docs/partials).
 3. Manually from within your [`Node`](/docs/nodes) or [`Tag`](/docs/tags) `transform` functions.
 


### PR DESCRIPTION
This PR moves content about config objects and about the fine points of tag syntax out of **Syntax and schema.** Config objects get their own topic, and the fine points of tag syntax go in **Tags.** 

This means that on both subjects, there's a single authoritative source of information that's listed in the left nav. **Syntax and schema** is an overview, but if you read **Tags,** you'll see everything you need to know about tags, with nothing left out. 