### PR TITLE
Clarifications

### DIFF
--- a/pages/docs/variables.md
+++ b/pages/docs/variables.md
@@ -15,15 +15,14 @@ Here I am rendering a custom {% $variable %}
 
 {% /markdoc-example %}
 
-You can pass variables in a few ways:
+As server-side data changes, you can present it in real time by re-rendering the page. Each re-render uses the variable's latest value.
 
-1. Through the `variables` field on your [`config` object](/docs/config)
-2. Via the [`variables` attribute](#with-partials) on a [`partial` tag](/docs/partials).
-3. Manually from within your [`Node`](/docs/nodes) or [`Tag`](/docs/tags) `transform` functions.
+(Some templating languages let variables change _during_ rendering, letting you use them in things like for loops. Markdoc doesn't do this, but it does offer [alternative ways](#alternatives) to do the same job.)
 
 ## Global variables
 
-Here's an example of how you can pass variables to your config:
+You can pass variables in several ways. The simplest is through the `variables` field on your [config](/docs/config) object.
+
 
 {% markdoc-example %}
 
@@ -51,21 +50,9 @@ const content = Markdoc.transform(ast, config);
 
 {% /markdoc-example %}
 
-which you can then access within your document:
+## Variables in partials
 
-{% markdoc-example %}
-
-```
-{% if $flags.my_feature_flag %}
-Username: {% $user.name %}
-{% /if %}
-```
-
-{% /markdoc-example %}
-
-## With partials
-
-To pass variables to a partial, set the `variables` attribute:
+You can also pass variables to a [partial](/docs/tags#partial). To do this, set the `variables` attribute:
 
 {% markdoc-example %}
 
@@ -75,7 +62,7 @@ To pass variables to a partial, set the `variables` attribute:
 
 {% /markdoc-example %}
 
-and access the value within your partial file the same way you would a regular variable:
+Access the value within your partial file the same way you would a regular variable:
 
 {% markdoc-example %}
 
@@ -85,6 +72,15 @@ Version: {% $version %}
 ```
 
 {% /markdoc-example %}
+
+## Alternatives
+
+Variables are immutable during page rendering. This keeps rendering behavior consistent and fast. But it means there are some tasks that you should use an alternative for:
+
+* To do calculations without side effects, use [custom or built-in Markdoc functions](/docs/functions).
+* To update a value during rendering, use a custom Markdoc transform function. For instance, [run a for loop](/docs/examples#loops) or [accumulate entries for a table of contents](/docs/examples#table-of-contents).
+
+
 
 ## Caveats
 


### PR DESCRIPTION
1. Introduce the idea that variables are immutable during rendering, and that that means some things have to happen in transform functions.
2. Still, make it clear that re-rendering lets you keep up with variables changing quickly between renders.
3. Remove redundant code from the example under "global variables."
4. A few style tweaks while I'm here.