### PR TITLE
Add fallback for parse errors

### DIFF
--- a/components/Sandbox.js
+++ b/components/Sandbox.js
@@ -39,7 +39,16 @@ Markdoc uses a fully declarative approach to composition and flow control, where
 const BASE_FRONTMATTER = { markdoc: { title: '' } };
 
 export function useMarkdocCode(code) {
-  const ast = React.useMemo(() => Markdoc.parse(code), [code]);
+  const ast = React.useMemo(() => {
+    try {
+      return Markdoc.parse(code);
+    } catch (error) {
+      console.log(error);
+      return Markdoc.parse(
+        `{% callout type="error" %}${error.message}{% /callout %}`
+      );
+    }
+  }, [code]);
 
   const config = React.useMemo(() => {
     const { components, ...rest } = getSchema(schema);


### PR DESCRIPTION
Fallback for https://github.com/markdoc/markdoc/issues/410

![image](https://github.com/markdoc/docs/assets/62121649/dcbb1e7b-120a-46f1-957c-fbf4a1402d80)
