### PR TITLE
Fix broken annotation links

### DIFF
--- a/pages/docs/syntax.md
+++ b/pages/docs/syntax.md
@@ -109,7 +109,9 @@ With tags, you can use an HTML-like syntax:
 
 {% /example %}
 
-Because the HTML-like syntax doesn't work with nodes, we offer another option: write the attributes after the tag or node you're passing them to, in a separate set of `{%` and `%}`. 
+## Annotations
+
+Because the HTML-like syntax doesn't work with nodes, we offer another option, called _annotations_: write the attributes after the tag or node you're passing them to, in a separate set of `{%` and `%}`.
 
 {% example %}
 


### PR DESCRIPTION
Several places link to `/docs/syntax#annotations`, but that anchor doesn't exist. Also the syntax page doesn't define or introduce annotations. After giving a rationale and example, it does hint that they are called annotations when it says "Annotation syntax also works with tags", but they should have been introduced before then.

This commit moves the annotations description out of Attributes by adding a new Annotations header (on the Syntax page), and tweaks the opening sentence to give a name to what it's describing. So now the links work and readers know what annotations are.